### PR TITLE
Update forecasting_job.py - Added documentation for forecast job's set_training method

### DIFF
--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
@@ -357,22 +357,22 @@ class ForecastingJob(AutoMLTabular):
         """
         The method to configure forecast training related settings.
 
-        :keyword enable_onnx_compatible_models:
+        :param enable_onnx_compatible_models:
             Whether to enable or disable enforcing the ONNX-compatible models.
             The default is False. For more information about Open Neural Network Exchange (ONNX) and Azure Machine
-            Learning,see this `article <https://docs.microsoft.com/azure/machine-learning/concept-onnx>`__.
-        :paramtype enable_onnx_compatible_models: typing.Optional[bool]
-        :keyword enable_dnn_training:
+            Learning, see this `article <https://docs.microsoft.com/azure/machine-learning/concept-onnx>`__.
+        :type: bool or None
+        :param enable_dnn_training:
             Whether to include DNN based models during model selection.
             However, the default is True for DNN NLP tasks, and it's False for all other AutoML tasks.
-        :paramtype enable_dnn_training: typing.Optional[bool]
-        :keyword enable_model_explainability:
+        :type: bool or None
+        :param enable_model_explainability:
             Whether to enable explaining the best AutoML model at the end of all AutoML training iterations.
             For more information, see `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
             , defaults to None
-        :paramtype enable_model_explainability: typing.Optional[bool]
-        :keyword enable_stack_ensemble:
+        :type: bool or None
+        :param enable_stack_ensemble:
             Whether to enable/disable StackEnsemble iteration.
             If `enable_onnx_compatible_models` flag is being set, then StackEnsemble iteration will be disabled.
             Similarly, for Timeseries tasks, StackEnsemble iteration will be disabled by default, to avoid risks of
@@ -380,30 +380,30 @@ class ForecastingJob(AutoMLTabular):
             For more information about ensembles, see `Ensemble configuration
             <https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#ensemble>`__
             , defaults to None
-        :paramtype enable_stack_ensemble: typing.Optional[bool]
-        :keyword enable_vote_ensemble:
+        :type: bool or None
+        :param enable_vote_ensemble:
             Whether to enable/disable VotingEnsemble iteration.
             For more information about ensembles, see `Ensemble configuration
             <https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#ensemble>`__
             , defaults to None
-        :paramtype enable_vote_ensemble: typing.Optional[bool]
-        :keyword stack_ensemble_settings:
+        :type: bool or None
+        :param stack_ensemble_settings:
             Settings for StackEnsemble iteration, defaults to None
-        :paramtype stack_ensemble_settings: typing.Optional[StackEnsembleSettings]
-        :keyword ensemble_model_download_timeout:
+        :type: StackEnsembleSettings or None
+        :param ensemble_model_download_timeout:
             During VotingEnsemble and StackEnsemble model generation,
             multiple fitted models from the previous child runs are downloaded. Configure this parameter with a
             higher value than 300 secs, if more time is needed, defaults to None
-        :paramtype ensemble_model_download_timeout: typing.Optional[int]
-        :keyword allowed_training_algorithms:
+        :type: int or None
+        :param allowed_training_algorithms:
             A list of model names to search for an experiment. If not specified,
             then all models supported for the task are used minus any specified in ``blocked_training_algorithms``
             or deprecated TensorFlow models, defaults to None
-        :paramtype allowed_training_algorithms: typing.Optional[List[str]]
-        :keyword blocked_training_algorithms:
+        :type: list(str) or None
+        :param blocked_training_algorithms:
             A list of algorithms to ignore for an experiment, defaults to None
-        :paramtype blocked_training_algorithms: typing.Optional[List[str]]
-        :keyword training_mode:
+        :type: list(str) or None
+        :param training_mode:
             [Experimental] The training mode to use.
             The possible values are-
 
@@ -414,7 +414,7 @@ class ForecastingJob(AutoMLTabular):
             * auto- Currently, it is same as non_distributed. In future, this might change.
 
             Note: This parameter is in public preview and may change in future.
-        :paramtype training_mode: typing.Optional[typing.Union[str, azure.ai.ml.constants.TabularTrainingMode]]
+        :type: azure.ai.ml.constants.TabularTrainingMode, str or None
         """
         super().set_training(
             enable_onnx_compatible_models=enable_onnx_compatible_models,

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
@@ -367,7 +367,7 @@ class ForecastingJob(AutoMLTabular):
             However, the default is True for DNN NLP tasks, and it's False for all other AutoML tasks.
         :paramtype enable_dnn_training: typing.Optional[bool]
         :keyword enable_model_explainability:
-            Whether to enable explaining the best AutoML model at the end of all AutoML training iterations. 
+            Whether to enable explaining the best AutoML model at the end of all AutoML training iterations.
             For more information, see `Interpretability: model explanations in automated machine learning
             <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
             , defaults to None
@@ -403,7 +403,7 @@ class ForecastingJob(AutoMLTabular):
         :keyword blocked_training_algorithms:
             A list of algorithms to ignore for an experiment, defaults to None
         :paramtype blocked_training_algorithms: typing.Optional[List[str]]
-        :keyword training_mode: 
+        :keyword training_mode:
             [Experimental] The training mode to use.
             The possible values are-
 

--- a/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
+++ b/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/tabular/forecasting_job.py
@@ -354,6 +354,68 @@ class ForecastingJob(AutoMLTabular):
         blocked_training_algorithms: Optional[List[str]] = None,
         training_mode: Optional[Union[str, TabularTrainingMode]] = None,
     ) -> None:
+        """
+        The method to configure forecast training related settings.
+
+        :keyword enable_onnx_compatible_models:
+            Whether to enable or disable enforcing the ONNX-compatible models.
+            The default is False. For more information about Open Neural Network Exchange (ONNX) and Azure Machine
+            Learning,see this `article <https://docs.microsoft.com/azure/machine-learning/concept-onnx>`__.
+        :paramtype enable_onnx_compatible_models: typing.Optional[bool]
+        :keyword enable_dnn_training:
+            Whether to include DNN based models during model selection.
+            However, the default is True for DNN NLP tasks, and it's False for all other AutoML tasks.
+        :paramtype enable_dnn_training: typing.Optional[bool]
+        :keyword enable_model_explainability:
+            Whether to enable explaining the best AutoML model at the end of all AutoML training iterations. 
+            For more information, see `Interpretability: model explanations in automated machine learning
+            <https://docs.microsoft.com/azure/machine-learning/how-to-machine-learning-interpretability-automl>`__.
+            , defaults to None
+        :paramtype enable_model_explainability: typing.Optional[bool]
+        :keyword enable_stack_ensemble:
+            Whether to enable/disable StackEnsemble iteration.
+            If `enable_onnx_compatible_models` flag is being set, then StackEnsemble iteration will be disabled.
+            Similarly, for Timeseries tasks, StackEnsemble iteration will be disabled by default, to avoid risks of
+            overfitting due to small training set used in fitting the meta learner.
+            For more information about ensembles, see `Ensemble configuration
+            <https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#ensemble>`__
+            , defaults to None
+        :paramtype enable_stack_ensemble: typing.Optional[bool]
+        :keyword enable_vote_ensemble:
+            Whether to enable/disable VotingEnsemble iteration.
+            For more information about ensembles, see `Ensemble configuration
+            <https://docs.microsoft.com/azure/machine-learning/how-to-configure-auto-train#ensemble>`__
+            , defaults to None
+        :paramtype enable_vote_ensemble: typing.Optional[bool]
+        :keyword stack_ensemble_settings:
+            Settings for StackEnsemble iteration, defaults to None
+        :paramtype stack_ensemble_settings: typing.Optional[StackEnsembleSettings]
+        :keyword ensemble_model_download_timeout:
+            During VotingEnsemble and StackEnsemble model generation,
+            multiple fitted models from the previous child runs are downloaded. Configure this parameter with a
+            higher value than 300 secs, if more time is needed, defaults to None
+        :paramtype ensemble_model_download_timeout: typing.Optional[int]
+        :keyword allowed_training_algorithms:
+            A list of model names to search for an experiment. If not specified,
+            then all models supported for the task are used minus any specified in ``blocked_training_algorithms``
+            or deprecated TensorFlow models, defaults to None
+        :paramtype allowed_training_algorithms: typing.Optional[List[str]]
+        :keyword blocked_training_algorithms:
+            A list of algorithms to ignore for an experiment, defaults to None
+        :paramtype blocked_training_algorithms: typing.Optional[List[str]]
+        :keyword training_mode: 
+            [Experimental] The training mode to use.
+            The possible values are-
+
+            * distributed- enables distributed training for supported algorithms.
+
+            * non_distributed- disables distributed training.
+
+            * auto- Currently, it is same as non_distributed. In future, this might change.
+
+            Note: This parameter is in public preview and may change in future.
+        :paramtype training_mode: typing.Optional[typing.Union[str, azure.ai.ml.constants.TabularTrainingMode]]
+        """
         super().set_training(
             enable_onnx_compatible_models=enable_onnx_compatible_models,
             enable_dnn_training=enable_dnn_training,


### PR DESCRIPTION
Added the documentation for forecast job's set_training method.

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.
